### PR TITLE
Fix refresh when adding new profile picture

### DIFF
--- a/src/views/admin/UserProfile.vue
+++ b/src/views/admin/UserProfile.vue
@@ -101,7 +101,8 @@ export default {
       });
   },
   methods: {
-    onSubmit() {
+    onSubmit(event) {
+    event.preventDefault();
       axios
         .post(
           `${process.env.VUE_APP_URI}/user`,


### PR DESCRIPTION
If you try to change the default profile picture, the page will refresh and the request will be dropped.
That's the solution ... I hope.