### PR TITLE
Error Update and socials

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -26,6 +26,7 @@
     const year = new Date().getFullYear()
     const links = [
         { name: "GitHub", href: "https://github.com/Asthriona", icon: "mdi:github" },
+        { name: "BlueSky", href: "https://bsky.app/profile/asthriona.bsky.social", icon: "fa6-brands:bluesky" },
         { name: "Twitter", href: "https://twitter.com/Asthriona", icon: "mdi:twitter" },
         { name: "YouTube", href: "https://youtube.com/@Asthriona", icon: "mdi:youtube" },
         { name: "Instagram", href: "https://www.instagram.com/asthriona.dev/", icon: "mdi:instagram" },

--- a/error.vue
+++ b/error.vue
@@ -7,13 +7,35 @@
         <!-- <p class="mt-7 text-7xl font-bold" v-else>{{ error.statusCode }}</p> -->
         
         <p class="mt-7 text-6xl">Oops.</p>
-        <p class="mt-7">{{ error.message }}</p>
+        <p class="mt-7" v-if="isRouteAnime == true" >{{ animeMessage }}</p>
+        <p class="mt-7" v-else>{{ error.message }}</p>
         <a href="/"><button class=" mt-7 text-sm font-semibold inline-block py-2 px-4 rounded-lg text-slate-300 uppercase last:mr-0 mr-4 border border-gradient-to-r from-cyan-500 to-blue-500">Go home!</button></a>
     </div>
 </template>
 
 <script setup>
     defineProps(['error'])
+    const route = useRoute()
+    let isRouteAnime;
+    let animeMessage;
+    route.name == 'anime' ? isRouteAnime = true : isRouteAnime = false
+    if (isRouteAnime == true) {
+        // check if Anilist is 200
+        fetch("https://anilist.co")
+        .then(res => {
+            console.log(res);
+            if (res.statusCode == 200) {
+                return animeMessage = "Something went wrong on our side."
+            } else {
+                return animeMessage = "Anilist seems to be down. Please try again  later."
+            }
+
+        })
+        .catch(err => {
+            console.log(err)
+            animeMessage = "Seems like Anilist is down. Please try again later."
+        })
+    }
 </script>
 
 <style>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.1.5",
+    "@iconify-json/fa6-brands": "^1.2.1",
     "@nuxt/image": "^1.8.1",
     "nuxt": "^3.13.2",
     "nuxt-icon": "^1.0.0-beta.7",
@@ -20,8 +21,9 @@
   "devDependencies": {
     "@iconify-json/mdi": "^1.2.1",
     "@nuxt/content": "^2.13.4",
-    "@nuxt/icon": "^1.6.1",
+    "@nuxt/icon": "^1.7.0",
     "@nuxtjs/tailwindcss": "^6.12.2",
     "@tailwindcss/typography": "^0.5.15"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
This PR add some better error handling for the anime page. 
It will now say that either something went wrong on the website or with Anilist instead of a generic error. 

I also added my bsky account to the footer icons. 
Twitter shall be removed once I completely moved out.