### PR TITLE
Fix images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Local Netlify folder
+.netlify

--- a/components/TheNavBars.vue
+++ b/components/TheNavBars.vue
@@ -13,7 +13,7 @@
           </div>
           <div class="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
             <div class="flex flex-shrink-0 items-center">
-              <a href="/"><img class="h-8 w-auto" src="https://cdn.asthriona.com/static/Asthriona-SL.svg" alt="Asthriona ltd." /></a>
+              <a href="/"><NuxtImg format="webp"  quality="40" class="h-8 w-auto" src="https://cdn.asthriona.com/static/Asthriona-SL.svg" alt="Asthriona ltd." /></a>
             </div>
             <div class="hidden sm:ml-6 sm:block">
               <div class="flex space-x-4">

--- a/components/ThePost.vue
+++ b/components/ThePost.vue
@@ -2,7 +2,7 @@
     <div v-for="post in props.posts" :key="post.slug"
         class="bg-black rounded-lg shadow-md overslow-hidden mt-8 border border-gradient-to-r from-cyan-500 to-blue-500">
         <NuxtLink :to="post._path">
-            <img :src="post.banner" alt="Blog Post cover image" class="w-full h-48 rounded object-cover object-center">
+            <NuxtImg format="webp"  quality="80" :src="post.banner" alt="Blog Post cover image" class="w-full h-48 rounded object-cover object-center" />
         </NuxtLink>
         <div class="p-6">
             <h2 class="text-xl font-bold mb-2">{{ post.title }}</h2>

--- a/content/blog/anime-page.md
+++ b/content/blog/anime-page.md
@@ -22,7 +22,7 @@ Instead nuxt takes care of it!
   
 Now, How did I make it and what was my thought process?  
 **LET ME EXPLAIN!!**  
-![An image in referance of Persona 5 when the player makes coffee and Sojiro explain the tast, but here represented as Neon Genesis Evangelion](/i/2024/10/%25pn_241031-194631.png)
+![An image in referance of Persona 5 when the player makes coffee and Sojiro explain the tast, but here represented as Neon Genesis Evangelion](https://cdn.asthriona.com/i/2024/11/letmeexplain.png)
 
 I wanted something that simply displays all the anime I'm watching, and order them in a specific order.  
 First things first, We need to query Anilist:  
@@ -253,7 +253,7 @@ const currentAnimeList = data?.value.animeList
     return bIsAiring - aIsAiring;
   });
 ```
-![screenshot of the order of the anime](/i/2024/10/firefox_241025-083636.png)  
+![screenshot of the order of the anime](https://cdn.asthriona.com/i/2024/10/firefox_241025-083636.png)  
 After changing the "data" in the template to "currentAnimeList" we get a smaller list with only what is currently being watched.   
 this list is in the right order; now we just need to make it pretty and decide what we want to show or not.   
   
@@ -287,7 +287,7 @@ this list is in the right order; now we just need to make it pretty and decide w
 ```
 with this instead of the "\{\{ currentAnimeList \}\}" at the top and with Tailwind, it looks pretty good already.  
 Feel free to make it your own, by editing the HTML or the data shown.
-![Screenshot of the result so far](/i/2024/10/explorer_241025-085713.png)  
+![Screenshot of the result so far](https://cdn.asthriona.com/i/2024/10/explorer_241025-085713.png)  
   
 I mentioned in the exemple a custom function to format the Airing time. Anilist has a funny way to display it, so here is the function:   
 ```javascript

--- a/content/blog/anime-page.md
+++ b/content/blog/anime-page.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating a Dynamic anime page!"
 description: "Are you wondering how I made my anime page? Let me Explain!"
-banner: "https://cdn.asthriona.com/i/2024/11/%25pn_241111-001426.jpg"
+banner: "https://cdn.asthriona.com/i/2024/11/anime-page-banner.jpg"
 published: true
 publishedDate: 10/25/2024
 editedDate: null

--- a/content/blog/anime-page.md
+++ b/content/blog/anime-page.md
@@ -22,7 +22,7 @@ Instead nuxt takes care of it!
   
 Now, How did I make it and what was my thought process?  
 **LET ME EXPLAIN!!**  
-![An image in referance of Persona 5 when the player makes coffee and Sojiro explain the tast, but here represented as Neon Genesis Evangelion](https://cdn.asthriona.com/i/2024/10/%25pn_241031-194631.png)
+![An image in referance of Persona 5 when the player makes coffee and Sojiro explain the tast, but here represented as Neon Genesis Evangelion](/i/2024/10/%25pn_241031-194631.png)
 
 I wanted something that simply displays all the anime I'm watching, and order them in a specific order.  
 First things first, We need to query Anilist:  
@@ -253,7 +253,7 @@ const currentAnimeList = data?.value.animeList
     return bIsAiring - aIsAiring;
   });
 ```
-![screenshot of the order of the anime](https://cdn.asthriona.com/i/2024/10/firefox_241025-083636.png)  
+![screenshot of the order of the anime](/i/2024/10/firefox_241025-083636.png)  
 After changing the "data" in the template to "currentAnimeList" we get a smaller list with only what is currently being watched.   
 this list is in the right order; now we just need to make it pretty and decide what we want to show or not.   
   
@@ -287,7 +287,7 @@ this list is in the right order; now we just need to make it pretty and decide w
 ```
 with this instead of the "\{\{ currentAnimeList \}\}" at the top and with Tailwind, it looks pretty good already.  
 Feel free to make it your own, by editing the HTML or the data shown.
-![Screenshot of the result so far](https://cdn.asthriona.com/i/2024/10/explorer_241025-085713.png)  
+![Screenshot of the result so far](/i/2024/10/explorer_241025-085713.png)  
   
 I mentioned in the exemple a custom function to format the Airing time. Anilist has a funny way to display it, so here is the function:   
 ```javascript

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [images]
-  remote_images = ["https://cdn.asthriona.com/*", "https://avatars.githubusercontent.com/*", "s4.anilist.co"]
+  remote_images = ["https://cdn.asthriona.com/*", "https://avatars.githubusercontent.com/*", "https://raw.githubusercontent.com/*", "https://s4.anilist.co/*"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [images]
-  remote_images = ["https://cdn.asthriona.com/*", "https://avatars.githubusercontent.com/*"]
+  remote_images = ["https://cdn.asthriona.com/*", "https://avatars.githubusercontent.com/*", "s4.anilist.co"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[images]
+  remote_images = ["https://cdn.asthriona.com/*"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [images]
-  remote_images = ["https://cdn.asthriona.com/*"]
+  remote_images = ["https://cdn.asthriona.com/*", "https://avatars.githubusercontent.com/*"]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
   image: {
     provider: 'netlify',
+    domains: ["cdn.asthriona.com"]
   },
   devtools: {
     enabled: true,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,9 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
+  image: {
+    provider: 'netlify',
+  },
   devtools: {
     enabled: true,
 

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -9,7 +9,7 @@
           class="w-24 h-24 rounded-full border-4 border-green-500" />
         <!-- Name and Bio -->
         <div>
-          <h1 class="text-3xl font-semibold">Makoto "<b>Asthriona</b>" Kobayahsi</h1>
+          <h1 class="text-3xl font-semibold">Makoto "<b>Asthriona</b>" Kobayashi</h1>
           <p class="text-gray-400">I do the code thing, and sometimes it works.</p>
         </div>
       </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -4,7 +4,8 @@
     <div class="max-w-7xl mx-auto flex items-center justify-between">
       <!-- Profile Image -->
       <div class="flex items-center space-x-4">
-        <img src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" alt="Profile"
+        <!-- <img  /> -->
+          <NuxtImg height="96" width="96" fit="cover" format="webp" quality="40" src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" alt="Profile"
           class="w-24 h-24 rounded-full border-4 border-green-500" />
         <!-- Name and Bio -->
         <div>
@@ -32,7 +33,7 @@
   <div class="flex items-center justify-between py-4 border-b-2 border-gray-200"></div>
   <div class="contributor-list" v-for="contributor in data" :key="contributor.login">
     <div class="flex items-center space-x-4 mb-4 mt-4">
-      <img :src="contributor.avatar_url" alt="Contributor" class="w-12 h-12 rounded-full" />
+      <NuxtImg height="48" width="48" fit="cover" format="webp" quality="40" :src="contributor.avatar_url" alt="Contributor" class="w-12 h-12 rounded-full" />
       <div>
         <a :href="contributor.html_url" target="_blank" rel="noopener noreferrer">{{ contributor.login }}</a>
         <span class="text-gray-500"> - {{ contributor.contributions }} contributions</span>

--- a/pages/anime.vue
+++ b/pages/anime.vue
@@ -2,10 +2,10 @@
   <div class="content">
     <div class="isError" v-if="isError == true">
       <div class="mt-7 max-sw-sm mx-auto text-center card">
-        <img class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/403.png" v-if="errorData.status == 403" />
-        <img class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/404.png" v-if="errorData.status == 404" />
-        <img class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/500.png" v-if="errorData.status == 500" />
-        <img class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/503.png" v-if="errorData.status == 503" />
+        <NuxtImg format="webp" quality="80" class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/403.png" v-if="errorData.status == 403" />
+        <NuxtImg format="webp" quality="80" class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/404.png" v-if="errorData.status == 404" />
+        <NuxtImg format="webp" quality="80" class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/500.png" v-if="errorData.status == 500" />
+        <NuxtImg format="webp" quality="80" class="mt-7 mx-auto w-1/2 h-1/2" src="~/assets/img/503.png" v-if="errorData.status == 503" />
 
         <p class="mt-7 text-3xl">{{ errorData.message }}</p>
         <a href="/"><button
@@ -18,13 +18,13 @@
       <!-- Hero Section -->
       <div class="relative h-[300px] mb-24">
         <div class="absolute inset-0 bg-gradient-to-b from-transparent to-black">
-          <img src="https://cdn.asthriona.com/i/2024/10/%25pn_241021-082337.jpg" alt="Profile Banner"
+          <NuxtImg format="webp" quality="80" height="300" width="1216" fit="cover" src="https://cdn.asthriona.com/i/2024/11/bluebox-banner.jpg" alt="Profile Banner"
             class="w-full h-full object-cover opacity-60" />
         </div>
 
         <!-- Profile Info -->
         <div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 flex flex-col items-center">
-          <img src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" alt="Profile Picture"
+          <NuxtImg format="webp" quality="80" src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" alt="Profile Picture"
             class="w-32 h-32 rounded-full border-4 border-cyan-500 shadow-lg shadow-cyan-500/20" />
           <div class="mt-4 text-center">
             <h1 class="text-3xl font-bold text-white">Asthriona</h1>
@@ -75,7 +75,7 @@
               <a :href="`https://anilist.co/anime/${anime.media.id}`" target="_blank">
                 <!-- Image Container -->
                 <div class="relative aspect-[3/4] overflow-hidden">
-                  <img :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
+                  <NuxtImg format="webp"  quality="80" :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
                     class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110" />
                   <div
                     class="absolute inset-0 bg-gradient-to-t from-slate-900 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -149,7 +149,7 @@
               class="group bg-slate-900/30 backdrop-blur-sm rounded-xl overflow-hidden transition-all duration-300 hover:scale-102 hover:shadow-xl hover:shadow-blue-500/10">
               <!-- Image Container -->
               <div class="relative aspect-[3/4] overflow-hidden">
-                <img :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
+                <NuxtImg format="webp"  quality="80" :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
                   class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110" />
                 <div
                   class="absolute inset-0 bg-gradient-to-t from-slate-900 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -211,7 +211,7 @@
               class="group bg-slate-900/30 backdrop-blur-sm rounded-xl overflow-hidden transition-all duration-300 hover:scale-102 hover:shadow-xl hover:shadow-blue-500/10">
               <!-- Image Container -->
               <div class="relative aspect-[3/4] overflow-hidden">
-                <img :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
+                <NuxtImg format="webp"  quality="80" :src="anime.media.coverImage.large" :alt="anime.media.title.romaji"
                   class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110" />
                 <div
                   class="absolute inset-0 bg-gradient-to-t from-slate-900 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -275,7 +275,7 @@
               class="group bg-slate-900/30 backdrop-blur-sm rounded-xl overflow-hidden transition-all duration-300 hover:scale-102 hover:shadow-xl hover:shadow-blue-500/10">
               <!-- Image Container -->
               <div class="relative aspect-[3/4] overflow-hidden">
-                <img :src="anime.media.coverImage.large" :alt="anime.media.title.native"
+                <NuxtImg format="webp"  quality="80" :src="anime.media.coverImage.large" :alt="anime.media.title.native"
                   class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110" />
                 <div
                   class="absolute inset-0 bg-gradient-to-t from-slate-900 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -1,5 +1,5 @@
 <template>
-    <img :src="data.banner" class="banner-img mx-auto max-w-7xl rounded-lg h-64 w-full object-cover" alt="">
+    <NuxtImg format="webp" quality="80" fit="cover" :src="data.banner" class="banner-img mx-auto max-w-7xl rounded-lg h-64 w-full object-cover" alt="" />
     <span class="mx-auto mt-7 text-slate-800">Publised on: {{ data.publishedDate }}</span>
     <ContentRenderer :value="data" class="prose my-10 mx-auto max-w-7xl text-slate-300" />
     <span class="mx-auto mt-7 text-slate-800" v-if="data.editedDate !== null">Last edited: {{ data.editedDate }}</span>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,8 @@
         <div class="md:w-2/4">
             <h2 class="text-3xl font-bold mt-8">Who am I?</h2>
             <p class="text-lg py-2">
-                I'm Asthriona, You can call me <i class="text-white">Makoto</i>, but most of my English speaking friends call me "<i class="text-white">Mako</i>" (except TheJudge who likes to call me "Mako-san").
+                I'm Asthriona, You can call me <i class="text-white">Makoto</i>, but most of my English speaking friends
+                call me "<i class="text-white">Mako</i>" (except TheJudge who likes to call me "Mako-san").
                 I'm a Full-Stack JS developper, who like to pick-up any sorts of skills, such as anything related to
                 cars, and computer science, lock picking, Video Games, whatever.
                 As a programer, I'm self-taught. I went to school for networking and datacenter management.
@@ -18,12 +19,14 @@
                 also anime, music, I can also enjoy some fine TV Shows and movies.
                 Meaning that I make this website as a hobby and for simple online presence, I really like the
                 "<i class="text-white">old-school</i>" internet, when it was filled with small blogs,
-                and places to share our daily lives and hobbies. In here I might share programing tips, Anime/TV Show/Movies review,
+                and places to share our daily lives and hobbies. In here I might share programing tips, Anime/TV
+                Show/Movies review,
                 but also try to keep the "project" page updated with my latests
                 project, and dev-logs.
             </p>
         </div>
-        <img format="webp" src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" alt="me" class="w-1/2 h-1/2 md:max-w-sm p8 mx-auto rounded"/>
+        <NuxtImg src="https://cdn.asthriona.com/i/2024/08/04853fceaae02025080e4b40392ff247.png" height="384" width="384"
+            fit="cover" format="webp" quality="80" class="w-1/2 h-1/2 md:max-w-sm p8 mx-auto rounded" />
     </section>
     <section>
         <h2 class="text-3xl font-bold mt-8">Latest Blog Posts</h2>


### PR DESCRIPTION
This PR Aim to improve overall performances from image loading. 
By moving all <img /> tags to <NuxtImg /> offering much more control over what the image looks like. 
For example my avatar being 700px is loaded with just 48px in the about page. 
The overall quality of the image has been lowered too. Most images are at 80% quality, and looks like 100% while saving bandwidth, and improving loadtime. 

Also, instead of loading from many sources, the images should be cached on netifly CDN and distributed that way.
Given their extensive infrastructure this improve loadtime. 
According to Netlify Lighthouse plugin the loadtime was reduced from 1200ms to only 300 (Still giving a result of 58 but greatly improved from the 38 before this change.)