### PR TITLE
chore(deps): bump vue from 3.5.25 to 3.5.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "better-sqlite3": "^12.2.0",
     "nuxt": "^4.1.1",
     "nuxt-icon": "^1.0.0-beta.7",
-    "vue": "3.5.25"
+    "vue": "3.5.28"
   },
   "devDependencies": {
     "@iconify-json/mdi": "^1.2.1",


### PR DESCRIPTION
### **User description**
Update of Vue from 3.5.25 to 3.5.28. 
it fixes Security issues if I remember correctly.
But most importantly, it keeps my Vue install updated. and THATS pretty cool!


___

### **PR Type**
Enhancement


___

### **Description**
- Bump Vue dependency from 3.5.25 to 3.5.28

- Applies patch version update for production dependency

- Addresses security issues and keeps framework updated


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update Vue to 3.5.28</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Updated <code>vue</code> dependency version from 3.5.25 to 3.5.28<br> <li> Patch version update for direct production dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/Asthriona/Asthriona.com/pull/197/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

